### PR TITLE
Add explicit place to change the status bar color

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -13,7 +13,7 @@ struct ComposeView: UIViewControllerRepresentable {
 struct ContentView: View {
     var body: some View {
         ComposeView()
-                .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+                .ignoresSafeArea(.all, edges: .bottom) // Compose has own keyboard handler
     }
 }
 

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -4,7 +4,10 @@ import SwiftUI
 struct iOSApp: App {
 	var body: some Scene {
 		WindowGroup {
-			ContentView()
+		    ZStack {
+		        Color.white.ignoresSafeArea(.all) // status bar color
+			    ContentView()
+			}.preferredColorScheme(.light)
 		}
 	}
 }


### PR DESCRIPTION
Explicitly sets the status bar color, so that people can find where to change it more easily.
Also removes the safe-area at the bottom, so that background colors stretch all the way to the bottom of the device.

Will most likely be revisited by the time safe zones and insets from Compose itself come around. Just want to stop people from having white bars whenever they build an app, with no way of changing it easily.

<img width="361" alt="Screenshot 2023-05-16 at 21 57 34" src="https://github.com/JetBrains/compose-multiplatform-ios-android-template/assets/2178959/125cd49b-a9ba-4b59-9434-64e7c9391bcb">

Let me know if you disagree with this decision or if disabling safe areas like this is a bad idea 😁 
