### PR TITLE
Gradle, android -> androidTarget

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
     sourceSets {
         val androidMain by getting {
             dependencies {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
 
     iosX64()
     iosArm64()


### PR DESCRIPTION
In Kotlin 1.9.0 Gradle DSL there are requirements to change deprecated `android` to `androidTarget`. It needs for future changes in Android Gradle plugin.