### PR TITLE
Add org.gradle.toolchains.foojay-resolver-convention

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -29,10 +29,10 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -59,10 +59,10 @@ android {
         minSdk = (findProperty("android.minSdk") as String).toInt()
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }


### PR DESCRIPTION
According to https://developer.android.com/build/jdks we should:

1. [use JDK 17 for API 34](https://developer.android.com/build/jdks#compileSdk)
2. [use toolchain](https://developer.android.com/build/jdks#toolchain):
```
We recommend that you always specify the Java toolchain, and either ensure that the specified JDK is installed, or add a toolchain resolver to your build.
```

As we don't want to force people to have JDK 17 on their machine, we apply toolchain resolver that is recommended by Gradle:
```
id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
```

It will download the toolchain itself.

## Test
1. Remove JDK 17 from the computer, remove `jvmToolchain(17)`
2. Run `./gradlew assembleDebug`
3. It should fail with:
```
> Could not create task ':androidApp:compileDebugJavaWithJavac'.
   > Failed to calculate the value of task ':androidApp:compileDebugJavaWithJavac' property 'javaCompiler'.
      > No matching toolchains found for requested specification: {languageVersion=17, vendor=any, implementation=vendor-specific} for WINDOWS on x86_64.
         > No locally installed toolchains match and toolchain download repositories have not been configured.
```
4. restore `jvmToolchain(17)`
5. Run `./gradlew assembleDebug` again
6. It should succeed

## Issues
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3615